### PR TITLE
Fix gazebo_ros:plugin_path in package.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Intel RealSense Gazebo ROS plugin
 
-This package is a Gazebo ROS plugin for the Intel D435 realsense camera, to add it in the [REEM-C](http://wiki.ros.org/Robots/REEM-C) 
-Gazebo simulation.
+This package is a Gazebo ROS plugin for the Intel D435 realsense camera.
  
 ## Acknowledgement
 

--- a/package.xml
+++ b/package.xml
@@ -27,7 +27,7 @@
 
   <export>
     <gazebo_ros
-      plugin_path="${prefix}/lib"
+      plugin_path="$(dirname $(catkin_find --first-only librealsense_gazebo_plugin.so))"
       gazebo_media_path="${prefix}"
       gazebo_model_path="${prefix}/models"
       />


### PR DESCRIPTION
Using `${prefix}/lib` is wrong. 

According to the [rospack implementation](https://github.com/ros/rospack/blob/8c5a699461f32f620204ccfaf93c5e5181f20f14/src/rospack.cpp#L2182), `${prefix}` is not context-dependent and get always expanded to the package path. If you're using devel space, this results in path to the package's source, not to the devel directory.

And really, this is from a DEBUG log of gazebo_ros.paths_plugin:

    [DEBUG] [1575894134.676531222]: plugin path /opt/ros/cras_subt/src/realsense_gazebo_plugin/lib

The subexpression used in the PR works so that it asks catkin for the absolute path to the built library and takes the directory it resides in. This expression is evaluated at launch time, so we can be sure the library is already built at that time.