### PR TITLE
Changed Distortion Model in Camera Info Messages

### DIFF
--- a/src/gazebo_ros_realsense.cpp
+++ b/src/gazebo_ros_realsense.cpp
@@ -251,6 +251,7 @@ sensor_msgs::CameraInfo cameraInfo(const sensor_msgs::Image &image,
   sensor_msgs::CameraInfo info_msg;
 
   info_msg.header = image.header;
+  info_msg.distortion_model = "plumb_bob";
   info_msg.height = image.height;
   info_msg.width = image.width;
 


### PR DESCRIPTION
Added common distortion model parameter to camera info shown [here](http://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html). Should I create a parameter handler so that this can be parsed by URDF or SDF?