### PR TITLE
Properly initialize distortion paramters

### DIFF
--- a/src/gazebo_ros_realsense.cpp
+++ b/src/gazebo_ros_realsense.cpp
@@ -269,6 +269,7 @@ sensor_msgs::CameraInfo cameraInfo(const sensor_msgs::Image &image,
   info_msg.P[6] = info_msg.K[5];
   info_msg.P[10] = info_msg.K[8];
 
+  info_msg.D = std::vector<double>(5, 0.0);
   //    info_msg.roi.do_rectify = true;
 
   return info_msg;


### PR DESCRIPTION
This is to avoid an empty distortion matrix in the ROS CameraInfo message.
When I used this package to simulate a realsense and used it with [moveit_calibration](https://github.com/ros-planning/moveit_calibration) to perform hand-eye calibration, it caused [this](https://github.com/ros-planning/moveit_calibration/issues/77) issue.