### PR TITLE
Fixed Pointcloud without color issue #48

### DIFF
--- a/include/realsense_gazebo_plugin/gazebo_ros_realsense.h
+++ b/include/realsense_gazebo_plugin/gazebo_ros_realsense.h
@@ -64,7 +64,9 @@ protected:
   /// \brief ROS image messages
 protected:
   sensor_msgs::Image image_msg_, depth_msg_;
+  sensor_msgs::Image image_msg2_;
   sensor_msgs::PointCloud2 pointcloud_msg_;
 };
+
 }
 #endif /* _GAZEBO_ROS_REALSENSE_PLUGIN_ */

--- a/src/gazebo_ros_realsense.cpp
+++ b/src/gazebo_ros_realsense.cpp
@@ -1,7 +1,6 @@
 #include "realsense_gazebo_plugin/gazebo_ros_realsense.h"
 #include <sensor_msgs/fill_image.h>
 #include <sensor_msgs/point_cloud2_iterator.h>
-#include <iostream>
 
 namespace {
 std::string extractCameraName(const std::string &name);


### PR DESCRIPTION
This for fixes the monochrome pointcloud issue #48  many users had with this package by checking the dimension of the sensor_msgs::Image image_msg_. 

The problem was that the colored rgb data was always overwritten by the monochrome pointcloud before getting published. I worked around this issue by creating a copy of image_msg_ called image_msgs2_ which stored the content of image_msg_ into image_msgs2_ when the size of the data was not monochrome but 3 dimensional (line 66). Later I simply used this stored color information when ever the color encoding was called instead of the by then overwritten image_msg_. 