### PR TITLE
Migrate plugin to ROS 2 Jazzy / Gazebo Harmonic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,47 +1,36 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(realsense_gazebo_plugin)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  # we dont use add_compile_options with pedantic in message packages
-  # because the Python C extensions dont comply with it
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wno-inconsistent-missing-override")
 endif()
 
-set(FastRTPS_INCLUDE_DIR /opt/ros/foxy/include)
-set(FastRTPS_LIBRARY_RELEASE /opt/ros/foxy/lib/libfastrtps.so)
-# Load catkin and all dependencies required for this package
+# Load all dependencies required for this package
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(gazebo_ros REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(point_cloud_transport REQUIRED)
 find_package(camera_info_manager REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-find_package(gazebo REQUIRED)
+# Find Gazebo Harmonic (gz-sim8) packages
+find_package(gz-sim8 REQUIRED)
+find_package(gz-plugin2 REQUIRED)
+find_package(gz-transport13 REQUIRED)
+find_package(gz-msgs10 REQUIRED)
 
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
-
-set( dependencies
+set(dependencies
     rclcpp
-    gazebo_ros
     image_transport
     point_cloud_transport
     camera_info_manager
     sensor_msgs
 )
-
-include_directories(
-    SYSTEM
-    include
-    ${GAZEBO_INCLUDE_DIRS}
-)
-
-link_directories(${GAZEBO_LIBRARY_DIRS})
 
 add_library(
     ${PROJECT_NAME} SHARED
@@ -49,8 +38,19 @@ add_library(
     src/gazebo_ros_realsense.cpp
 )
 
+target_include_directories(${PROJECT_NAME} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
-target_link_libraries(${PROJECT_NAME} ${GAZEBO_LIBRARIES})
+
+target_link_libraries(${PROJECT_NAME}
+    gz-sim8::gz-sim8
+    gz-plugin2::gz-plugin2
+    gz-transport13::gz-transport13
+    gz-msgs10::gz-msgs10
+)
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION lib

--- a/README.md
+++ b/README.md
@@ -1,267 +1,51 @@
 # Intel RealSense Gazebo ROS plugin
 
-This package is a Gazebo ROS plugin for the Intel D435 realsense camera.
+This package provides a Gazebo Harmonic (`gz-sim`) ROS 2 plugin for the Intel D435 RealSense camera.
 
 ## Note
-This branch is aimed for ROS2, if you are ROS1 user you can see the other branches(e.g melodic)
- 
-## Acknowledgement
 
-This is a continuation of work done by [SyrianSpock](https://github.com/SyrianSpock) for a Gazebo ROS plugin with RS200 camera.
-
-This package also includes the work developed by Intel Corporation with the ROS model for the [D435](https://github.com/intel-ros/realsense) camera.
+This branch targets ROS 2 Jazzy with Gazebo Harmonic (`gz-sim 8`). If you need a Gazebo Classic setup, use the branch that still depends on `gazebo_ros_pkgs`.
 
 ## Example usage with a custom robot
 
-Note that this was tested for the ROS2 branch with ROS Foxy distro. A turtlebot3 like custom robot model was used. 
-In custom robot's `model.sdf`, we should attach the link, sensors, joint  and plugin block as following; 
+In Gazebo Harmonic, simulated sensors publish over native gz-transport topics. This plugin must be told which native sensor topics to subscribe to, and it also needs the configured horizontal field of view values so it can generate ROS camera info messages.
+
+Use `gz topic -l` to find the exact sensor topic paths for your model.
 
 ```xml
-    <link name="realsense_link">
-      <pose>0.4 0 0.25 0 0 0</pose>
-      <visual name="realsense_link_visual">
-        <pose>0 0 0 -1.57 0 -1.57</pose>
-        <geometry>
-          <mesh>
-            <uri>model://chiconybot/meshes/d435.dae</uri>
-          </mesh>
-        </geometry>
-      </visual>
-      <collision name="realsense_link_collision">
-        <pose>0 0 0 -1.57 0 -1.57</pose>
-        <geometry>
-          <box>
-            <size>0.02505 0.090 0.025</size>
-          </box>
-        </geometry>
-      </collision>
-      <inertial>
-        <pose>0 0 0 0 0 0</pose>
-        <inertia>
-          <ixx>0.001</ixx>
-          <ixy>0.000</ixy>
-          <ixz>0.000</ixz>
-          <iyy>0.001</iyy>
-          <iyz>0.000</iyz>
-          <izz>0.001</izz>
-        </inertia>
-        <mass>0.564</mass>
-      </inertial>
+<plugin name="realsense_gazebo_plugin::GazeboRosRealsense" filename="librealsense_gazebo_plugin.so">
+  <prefix>camera</prefix>
+  <depthUpdateRate>30.0</depthUpdateRate>
+  <colorUpdateRate>30.0</colorUpdateRate>
+  <infraredUpdateRate>1.0</infraredUpdateRate>
 
-      <sensor name="cameradepth" type="depth">
-        <camera name="camera">
-          <horizontal_fov>1.57</horizontal_fov>
-          <image>
-            <width>1280</width>
-            <height>720</height>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>100</far>
-          </clip>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>0.100</stddev>
-          </noise>
-        </camera>
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <visualize>0</visualize>
-      </sensor>
-      <sensor name="cameracolor" type="camera">
-        <camera name="camera">
-          <horizontal_fov>1.57</horizontal_fov>
-          <image>
-            <width>1280</width>
-            <height>720</height>
-            <format>RGB_INT8</format>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>100</far>
-          </clip>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>0.007</stddev>
-          </noise>
-        </camera>
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <visualize>1</visualize>
-      </sensor>
-      <sensor name="cameraired1" type="camera">
-        <camera name="camera">
-          <horizontal_fov>1.57</horizontal_fov>
-          <image>
-            <width>1280</width>
-            <height>720</height>
-            <format>L_INT8</format>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>100</far>
-          </clip>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>0.05</stddev>
-          </noise>
-        </camera>
-        <always_on>1</always_on>
-        <update_rate>1</update_rate>
-        <visualize>0</visualize>
-      </sensor>
-      <sensor name="cameraired2" type="camera">
-        <camera name="camera">
-          <horizontal_fov>1.57</horizontal_fov>
-          <image>
-            <width>1280</width>
-            <height>720</height>
-            <format>L_INT8</format>
-          </image>
-          <clip>
-            <near>0.1</near>
-            <far>100</far>
-          </clip>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>0.05</stddev>
-          </noise>
-        </camera>
-        <always_on>1</always_on>
-        <update_rate>1</update_rate>
-        <visualize>0</visualize>
-      </sensor>
-    </link>
+  <!-- Gazebo Harmonic native topics to subscribe to -->
+  <gzDepthTopic>/world/default/model/chiconybot/link/realsense_link/sensor/cameradepth/depth_image</gzDepthTopic>
+  <gzColorTopic>/world/default/model/chiconybot/link/realsense_link/sensor/cameracolor/image</gzColorTopic>
+  <gzInfrared1Topic>/world/default/model/chiconybot/link/realsense_link/sensor/cameraired1/image</gzInfrared1Topic>
+  <gzInfrared2Topic>/world/default/model/chiconybot/link/realsense_link/sensor/cameraired2/image</gzInfrared2Topic>
 
-    <joint name="realsense_joint" type="fixed">
-      <parent>base_link</parent>
-      <child>realsense_link</child>
-      <pose>0.4 0 0.4 0 0 0</pose>
-    </joint>
+  <depthHFOV>1.57</depthHFOV>
+  <colorHFOV>1.57</colorHFOV>
+  <infraredHFOV>1.57</infraredHFOV>
 
-    <plugin name="camera" filename="librealsense_gazebo_plugin.so">
-      <prefix>camera</prefix>
-      <depthUpdateRate>30.0</depthUpdateRate>
-      <colorUpdateRate>30.0</colorUpdateRate>
-      <infraredUpdateRate>1.0</infraredUpdateRate>
-      <depthTopicName>aligned_depth_to_color/image_raw</depthTopicName>
-      <depthCameraInfoTopicName>depth/camera_info</depthCameraInfoTopicName>
-      <colorTopicName>color/image_raw</colorTopicName>
-      <colorCameraInfoTopicName>color/camera_info</colorCameraInfoTopicName>
-      <infrared1TopicName>infra1/image_raw</infrared1TopicName>
-      <infrared1CameraInfoTopicName>infra1/camera_info</infrared1CameraInfoTopicName>
-      <infrared2TopicName>infra2/image_raw</infrared2TopicName>
-      <infrared2CameraInfoTopicName>infra2/camera_info</infrared2CameraInfoTopicName>
-      <colorOpticalframeName>camera_color_optical_frame</colorOpticalframeName>
-      <depthOpticalframeName>camera_depth_optical_frame</depthOpticalframeName>
-      <infrared1OpticalframeName>camera_left_ir_optical_frame</infrared1OpticalframeName>
-      <infrared2OpticalframeName>camera_right_ir_optical_frame</infrared2OpticalframeName>
-      <rangeMinDepth>0.3</rangeMinDepth>
-      <rangeMaxDepth>3.0</rangeMaxDepth>
-      <pointCloud>true</pointCloud>
-      <pointCloudTopicName>depth/color/points</pointCloudTopicName>
-      <pointCloudCutoff>0.3</pointCloudCutoff>
-    </plugin>
-```
-
-Finally we should define the joint, links of each camera(color, depth, ir_right, ir_left) W.R.T robot body, 
-In URDF(usually in `xxx_description` package) of the robot add following; 
-
-```xml
-  <link name="camera_bottom_screw_frame">
-    <visual>
-      <geometry>
-        <mesh filename="package://chiconybot_description/meshes/sensors/d435.dae" />
-      </geometry>
-    </visual>
-    <collision>
-      <geometry>
-        <mesh filename="package://chiconybot_description/meshes/sensors/d435.dae" />
-      </geometry>
-    </collision>
-  </link>
-
-  <link name="camera_link"></link>
-
-  <link name="camera_depth_frame"></link>
-
-  <link name="camera_depth_optical_frame"></link>
-
-  <link name="camera_color_frame"></link>
-
-  <link name="camera_color_optical_frame"></link>
-
-  <link name="camera_left_ir_frame"></link>
-
-  <link name="camera_left_ir_optical_frame"></link>
-
-  <link name="camera_right_ir_frame"></link>
-
-  <link name="camera_right_ir_optical_frame"></link>
-
-
-   <joint name="camera_joint" type="fixed">
-    <parent link="base_link" />
-    <child link="camera_bottom_screw_frame" />
-    <pose xyz="0.4 0 0.25" rpy="0 0 0" />
-  </joint>
-
-  <joint name="camera_link_joint" type="fixed">
-    <parent link="camera_bottom_screw_frame" />
-    <child link="camera_link" />
-    <pose xyz="0 0.0175 0.0125 " rpy="0 0 0" />
-  </joint>
-
-  <joint name="camera_depth_joint" type="fixed">
-    <parent link="camera_link" />
-    <child link="camera_depth_frame" />
-    <pose xyz="0 0 0" rpy="0 0 0" />
-  </joint>
-
-  <joint name="camera_depth_optical_joint" type="fixed">
-    <parent link="camera_depth_frame" />
-    <child link="camera_depth_optical_frame" />
-    <pose xyz="0 0 0 " rpy="-1.57 0 -1.57" />
-  </joint>
-
-  <joint name="camera_color_joint" type="fixed">
-    <parent link="camera_depth_frame" />
-    <child link="camera_color_frame" />
-    <pose xyz="0 0 0" rpy="0 0 0" />
-  </joint>
-
-  <joint name="camera_color_optical_joint" type="fixed">
-    <parent link="camera_color_frame" />
-    <child link="camera_color_optical_frame" />
-    <pose xyz="0 0 0 " rpy="-1.57 0 -1.57" />
-  </joint>
-
-  <joint name="camera_left_ir_joint" type="fixed">
-    <parent link="camera_depth_frame" />
-    <child link="camera_left_ir_frame" />
-    <pose xyz="0 0 0 " rpy="0 0 0 " />
-  </joint>
-
-  <joint name="camera_left_ir_optical_joint" type="fixed">
-    <parent link="camera_left_ir_frame" />
-    <child link="camera_left_ir_optical_frame" />
-    <pose xyz="0 0 0 " rpy="-1.57 0 -1.57" />
-  </joint>
-
-  <joint name="camera_right_ir_joint" type="fixed">
-    <parent link="camera_depth_frame" />
-    <child link="camera_right_ir_frame" />
-    <pose xyz="0 -0.050 0 " rpy="0 0 0" />
-  </joint>
-
-  <joint name="camera_right_ir_optical_joint" type="fixed">
-    <parent link="camera_right_ir_frame" />
-    <child link="camera_right_ir_optical_frame" />
-    <pose xyz="0 0 0 " rpy="-1.57 0 -1.57" />
-  </joint>
-
+  <!-- ROS topic configuration -->
+  <depthTopicName>aligned_depth_to_color/image_raw</depthTopicName>
+  <depthCameraInfoTopicName>depth/camera_info</depthCameraInfoTopicName>
+  <colorTopicName>color/image_raw</colorTopicName>
+  <colorCameraInfoTopicName>color/camera_info</colorCameraInfoTopicName>
+  <infrared1TopicName>infra1/image_raw</infrared1TopicName>
+  <infrared1CameraInfoTopicName>infra1/camera_info</infrared1CameraInfoTopicName>
+  <infrared2TopicName>infra2/image_raw</infrared2TopicName>
+  <infrared2CameraInfoTopicName>infra2/camera_info</infrared2CameraInfoTopicName>
+  <colorOpticalframeName>camera_color_optical_frame</colorOpticalframeName>
+  <depthOpticalframeName>camera_depth_optical_frame</depthOpticalframeName>
+  <infrared1OpticalframeName>camera_left_ir_optical_frame</infrared1OpticalframeName>
+  <infrared2OpticalframeName>camera_right_ir_optical_frame</infrared2OpticalframeName>
+  <rangeMinDepth>0.3</rangeMinDepth>
+  <rangeMaxDepth>3.0</rangeMaxDepth>
+  <pointCloud>true</pointCloud>
+  <pointCloudTopicName>depth/color/points</pointCloudTopicName>
+  <pointCloudCutoff>0.3</pointCloudCutoff>
+</plugin>
 ```

--- a/include/realsense_gazebo_plugin/RealSensePlugin.hpp
+++ b/include/realsense_gazebo_plugin/RealSensePlugin.hpp
@@ -19,15 +19,13 @@
 #include <vector>
 #include <map>
 
-#include <gazebo/common/Plugin.hh>
-#include <gazebo/common/common.hh>
-#include <gazebo/physics/PhysicsTypes.hh>
-#include <gazebo/physics/physics.hh>
-#include <gazebo/rendering/DepthCamera.hh>
-#include <gazebo/sensors/sensors.hh>
-#include <sdf/sdf.hh>
+#include <gz/sim/System.hh>
+#include <gz/sim/Entity.hh>
+#include <gz/sim/Model.hh>
+#include <gz/transport/Node.hh>
+#include <gz/msgs/image.pb.h>
 
-namespace gazebo
+namespace realsense_gazebo_plugin
 {
 #define DEPTH_CAMERA_NAME "depth"
 #define COLOR_CAMERA_NAME "color"
@@ -36,97 +34,35 @@ namespace gazebo
 
 struct CameraParams
 {
-  CameraParams()
-  {
-  }
-
   std::string topic_name;
   std::string camera_info_topic_name;
   std::string optical_frame;
+  std::string gz_topic;
+  double hfov;
 };
 
-/// \brief A plugin that simulates Real Sense camera streams.
-class RealSensePlugin : public ModelPlugin
+/// \brief A plugin that simulates Real Sense camera streams via Gazebo Transport.
+class RealSensePlugin : public gz::sim::System,
+                        public gz::sim::ISystemConfigure
 {
-  /// \brief Constructor.
-
 public:
   RealSensePlugin();
+  ~RealSensePlugin() override;
 
-  /// \brief Destructor.
-  ~RealSensePlugin();
+  void Configure(const gz::sim::Entity &_entity,
+                 const std::shared_ptr<const sdf::Element> &_sdf,
+                 gz::sim::EntityComponentManager &_ecm,
+                 gz::sim::EventManager &_eventMgr) override;
 
-  // Documentation Inherited.
-  virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
-
-  /// \brief Callback for the World Update event.
-  void OnUpdate();
-
-  /// \brief Callback that publishes a received Depth Camera Frame as an
-  /// ImageStamped
-  /// message.
-  virtual void OnNewDepthFrame();
-
-  /// \brief Callback that publishes a received Camera Frame as an
-  /// ImageStamped message.
-  virtual void OnNewFrame(
-    const rendering::CameraPtr cam,
-    const transport::PublisherPtr pub);
+  virtual void OnNewDepthFrame(const gz::msgs::Image & _msg);
+  virtual void OnNewColorFrame(const gz::msgs::Image & _msg);
+  virtual void OnNewInfrared1Frame(const gz::msgs::Image & _msg);
+  virtual void OnNewInfrared2Frame(const gz::msgs::Image & _msg);
 
 protected:
-  /// \brief Pointer to the model containing the plugin.
-  physics::ModelPtr rsModel;
-
-  /// \brief Pointer to the world.
-  physics::WorldPtr world;
-
-  /// \brief Pointer to the Depth Camera Renderer.
-  rendering::DepthCameraPtr depthCam;
-
-  /// \brief Pointer to the Color Camera Renderer.
-  rendering::CameraPtr colorCam;
-
-  /// \brief Pointer to the Infrared Camera Renderer.
-  rendering::CameraPtr ired1Cam;
-
-  /// \brief Pointer to the Infrared2 Camera Renderer.
-  rendering::CameraPtr ired2Cam;
-
-  /// \brief String to hold the camera prefix
   std::string prefix;
-
-  /// \brief Pointer to the transport Node.
-  transport::NodePtr transportNode;
-
-  // \brief Store Real Sense depth map data.
+  gz::transport::Node transportNode;
   std::vector<uint16_t> depthMap;
-
-  /// \brief Pointer to the Depth Publisher.
-  transport::PublisherPtr depthPub;
-
-  /// \brief Pointer to the Color Publisher.
-  transport::PublisherPtr colorPub;
-
-  /// \brief Pointer to the Infrared Publisher.
-  transport::PublisherPtr ired1Pub;
-
-  /// \brief Pointer to the Infrared2 Publisher.
-  transport::PublisherPtr ired2Pub;
-
-  /// \brief Pointer to the Depth Camera callback connection.
-  event::ConnectionPtr newDepthFrameConn;
-
-  /// \brief Pointer to the Depth Camera callback connection.
-  event::ConnectionPtr newIred1FrameConn;
-
-  /// \brief Pointer to the Infrared Camera callback connection.
-  event::ConnectionPtr newIred2FrameConn;
-
-  /// \brief Pointer to the Color Camera callback connection.
-  event::ConnectionPtr newColorFrameConn;
-
-  /// \brief Pointer to the World Update event connection.
-  event::ConnectionPtr updateConnection;
 
   std::map<std::string, CameraParams> cameraParamsMap_;
 
@@ -141,4 +77,4 @@ protected:
   float rangeMinDepth_;
   float rangeMaxDepth_;
 };
-}  // namespace gazebo
+}  // namespace realsense_gazebo_plugin

--- a/include/realsense_gazebo_plugin/gazebo_ros_realsense.hpp
+++ b/include/realsense_gazebo_plugin/gazebo_ros_realsense.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+#include <mutex>
 
 #include <camera_info_manager/camera_info_manager.hpp>
 #include <image_transport/image_transport.hpp>
@@ -48,7 +49,8 @@ public:
 
   bool FillPointCloudHelper(
     sensor_msgs::msg::PointCloud2 & point_cloud_msg, uint32_t rows_arg,
-    uint32_t cols_arg, uint32_t step_arg, const void * data_arg);
+    uint32_t cols_arg, uint32_t step_arg, const void * data_arg,
+    const sensor_msgs::msg::Image & color_msg);
 
 protected:
   std::shared_ptr<camera_info_manager::CameraInfoManager> camera_info_manager_;
@@ -58,7 +60,10 @@ protected:
   image_transport::CameraPublisher color_pub_, ir1_pub_, ir2_pub_, depth_pub_;
   point_cloud_transport::Publisher pointcloud_pub_;
 
-  sensor_msgs::msg::Image image_msg_, depth_msg_;
+  sensor_msgs::msg::Image depth_msg_;
   sensor_msgs::msg::PointCloud2 pointcloud_msg_;
+
+  std::mutex color_mutex_;
+  sensor_msgs::msg::Image latest_color_msg_;
 };
 }  // namespace realsense_gazebo_plugin

--- a/include/realsense_gazebo_plugin/gazebo_ros_realsense.hpp
+++ b/include/realsense_gazebo_plugin/gazebo_ros_realsense.hpp
@@ -27,67 +27,38 @@
 
 #include "realsense_gazebo_plugin/RealSensePlugin.hpp"
 
-namespace gazebo
+namespace realsense_gazebo_plugin
 {
-/// \brief A plugin that simulates Real Sense camera streams.
+
 class GazeboRosRealsense : public RealSensePlugin
 {
-  /// \brief Constructor.
-
 public:
   GazeboRosRealsense();
+  ~GazeboRosRealsense() override;
 
-  /// \brief Destructor.
+  void Configure(const gz::sim::Entity &_entity,
+                 const std::shared_ptr<const sdf::Element> &_sdf,
+                 gz::sim::EntityComponentManager &_ecm,
+                 gz::sim::EventManager &_eventMgr) override;
 
-public:
-  ~GazeboRosRealsense();
+  void OnNewDepthFrame(const gz::msgs::Image & _msg) override;
+  void OnNewColorFrame(const gz::msgs::Image & _msg) override;
+  void OnNewInfrared1Frame(const gz::msgs::Image & _msg) override;
+  void OnNewInfrared2Frame(const gz::msgs::Image & _msg) override;
 
-  // Documentation Inherited.
-
-public:
-  virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
-
-  /// \brief Callback that publishes a received Depth Camera Frame as an
-  /// ImageStamped message.
-
-public:
-  virtual void OnNewDepthFrame();
-
-  /// \brief Helper function to fill the pointcloud information
   bool FillPointCloudHelper(
-    sensor_msgs::msg::PointCloud2 & point_cloud_msg,
-    uint32_t rows_arg, uint32_t cols_arg,
-    uint32_t step_arg, const void * data_arg);
-
-  /// \brief Callback that publishes a received Camera Frame as an
-  /// ImageStamped message.
-
-public:
-  virtual void OnNewFrame(
-    const rendering::CameraPtr cam,
-    const transport::PublisherPtr pub);
+    sensor_msgs::msg::PointCloud2 & point_cloud_msg, uint32_t rows_arg,
+    uint32_t cols_arg, uint32_t step_arg, const void * data_arg);
 
 protected:
-  boost::shared_ptr<camera_info_manager::CameraInfoManager>
-  camera_info_manager_;
-
-  /// \brief A pointer to the ROS node.
-  ///  A node will be instantiated if it does not exist.
-
-protected:
+  std::shared_ptr<camera_info_manager::CameraInfoManager> camera_info_manager_;
   rclcpp::Node::SharedPtr node_;
-
-private:
   std::unique_ptr<point_cloud_transport::PointCloudTransport> pctnode_;
 
-protected:
   image_transport::CameraPublisher color_pub_, ir1_pub_, ir2_pub_, depth_pub_;
   point_cloud_transport::Publisher pointcloud_pub_;
 
-  /// \brief ROS image messages
-
-protected:
   sensor_msgs::msg::Image image_msg_, depth_msg_;
   sensor_msgs::msg::PointCloud2 pointcloud_msg_;
 };
-}  // namespace gazebo
+}  // namespace realsense_gazebo_plugin

--- a/package.xml
+++ b/package.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>realsense_gazebo_plugin</name>
   <version>3.2.0</version>
-  <description>Intel RealSense D435 Gazebo plugin package</description>
+  <description>Intel RealSense D435 Gazebo Harmonic plugin package for ROS 2 Jazzy</description>
 
   <maintainer email="sergey.dorodnicov@intel.com">Sergey Dorodnicov</maintainer>
   <maintainer email="doron.hirshberg@intel.com">Doron Hirshberg</maintainer>
@@ -21,18 +22,20 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>gazebo_ros</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>image_transport</depend>
   <depend>point_cloud_transport</depend>
   <depend>camera_info_manager</depend>
+  <depend>gz_sim_vendor</depend>
+  <depend>gz_plugin_vendor</depend>
+  <depend>gz_transport_vendor</depend>
+  <depend>gz_msgs_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  
+
   <export>
-    <gazebo_ros plugin_path="${prefix}/lib" gazebo_media_path="${prefix}" gazebo_model_path="${prefix}/models" />
     <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/src/RealSensePlugin.cpp
+++ b/src/RealSensePlugin.cpp
@@ -13,282 +13,92 @@
 // limitations under the License.
 
 #include "realsense_gazebo_plugin/RealSensePlugin.hpp"
-#include <gazebo/physics/physics.hh>
-#include <gazebo/rendering/DepthCamera.hh>
-#include <gazebo/sensors/sensors.hh>
+#include <iostream>
+#include <limits>
 
 #define DEPTH_SCALE_M 0.001
 
-#define DEPTH_CAMERA_TOPIC "depth"
-#define COLOR_CAMERA_TOPIC "color"
-#define IRED1_CAMERA_TOPIC "infrared"
-#define IRED2_CAMERA_TOPIC "infrared2"
-
-namespace gazebo
+namespace realsense_gazebo_plugin
 {
 
-/////////////////////////////////////////////////
 RealSensePlugin::RealSensePlugin()
-{
-  this->depthCam = nullptr;
-  this->ired1Cam = nullptr;
-  this->ired2Cam = nullptr;
-  this->colorCam = nullptr;
-  this->prefix = "";
-  this->pointCloudCutOffMax_ = 5.0;
-}
+: pointCloudCutOff_(0.0),
+  pointCloudCutOffMax_(5.0),
+  colorUpdateRate_(0.0),
+  infraredUpdateRate_(0.0),
+  depthUpdateRate_(0.0),
+  rangeMinDepth_(0.0f),
+  rangeMaxDepth_(std::numeric_limits<float>::max())
+{}
 
-/////////////////////////////////////////////////
 RealSensePlugin::~RealSensePlugin() {}
 
-/////////////////////////////////////////////////
-void RealSensePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+void RealSensePlugin::Configure(const gz::sim::Entity & /*_entity*/,
+                                const std::shared_ptr<const sdf::Element> &_sdf,
+                                gz::sim::EntityComponentManager & /*_ecm*/,
+                                gz::sim::EventManager & /*_eventMgr*/)
 {
-  // Output the name of the model
-  std::cout
-    << std::endl
-    << "RealSensePlugin: The realsense_camera plugin is attach to model "
-    << _model->GetName() << std::endl;
-
-  _sdf = _sdf->GetFirstElement();
-
   cameraParamsMap_.insert(std::make_pair(COLOR_CAMERA_NAME, CameraParams()));
   cameraParamsMap_.insert(std::make_pair(DEPTH_CAMERA_NAME, CameraParams()));
   cameraParamsMap_.insert(std::make_pair(IRED1_CAMERA_NAME, CameraParams()));
   cameraParamsMap_.insert(std::make_pair(IRED2_CAMERA_NAME, CameraParams()));
 
-  do {
-    std::string name = _sdf->GetName();
-    if (name == "depthUpdateRate") {
-      _sdf->GetValue()->Get(depthUpdateRate_);
-    } else if (name == "colorUpdateRate") {
-      _sdf->GetValue()->Get(colorUpdateRate_);
-    } else if (name == "infraredUpdateRate") {
-      _sdf->GetValue()->Get(infraredUpdateRate_);
-    } else if (name == "depthTopicName") {
-      cameraParamsMap_[DEPTH_CAMERA_NAME].topic_name =
-        _sdf->GetValue()->GetAsString();
-    } else if (name == "depthCameraInfoTopicName") {
-      cameraParamsMap_[DEPTH_CAMERA_NAME].camera_info_topic_name =
-        _sdf->GetValue()->GetAsString();
-    } else if (name == "colorTopicName") {
-      cameraParamsMap_[COLOR_CAMERA_NAME].topic_name =
-        _sdf->GetValue()->GetAsString();
-    } else if (name == "colorCameraInfoTopicName") {
-      cameraParamsMap_[COLOR_CAMERA_NAME].camera_info_topic_name =
-        _sdf->GetValue()->GetAsString();
-    } else if (name == "infrared1TopicName") {
-      cameraParamsMap_[IRED1_CAMERA_NAME].topic_name =
-        _sdf->GetValue()->GetAsString();
-    } else if (name == "infrared1CameraInfoTopicName") {
-      cameraParamsMap_[IRED1_CAMERA_NAME].camera_info_topic_name =
-        _sdf->GetValue()->GetAsString();
-    } else if (name == "infrared2TopicName") {
-      cameraParamsMap_[IRED2_CAMERA_NAME].topic_name =
-        _sdf->GetValue()->GetAsString();
-    } else if (name == "infrared2CameraInfoTopicName") {
-      cameraParamsMap_[IRED2_CAMERA_NAME].camera_info_topic_name =
-        _sdf->GetValue()->GetAsString();
-    } else if (name == "colorOpticalframeName") {
-      cameraParamsMap_[COLOR_CAMERA_NAME].optical_frame =
-        _sdf->GetValue()->GetAsString();
-    } else if (name == "depthOpticalframeName") {
-      cameraParamsMap_[DEPTH_CAMERA_NAME].optical_frame =
-        _sdf->GetValue()->GetAsString();
-    } else if (name == "infrared1OpticalframeName") {
-      cameraParamsMap_[IRED1_CAMERA_NAME].optical_frame =
-        _sdf->GetValue()->GetAsString();
-    } else if (name == "infrared2OpticalframeName") {
-      cameraParamsMap_[IRED2_CAMERA_NAME].optical_frame =
-        _sdf->GetValue()->GetAsString();
-    } else if (name == "rangeMinDepth") {
-      _sdf->GetValue()->Get(rangeMinDepth_);
-    } else if (name == "rangeMaxDepth") {
-      _sdf->GetValue()->Get(rangeMaxDepth_);
-    } else if (name == "pointCloud") {
-      _sdf->GetValue()->Get(pointCloud_);
-    } else if (name == "pointCloudTopicName") {
-      pointCloudTopic_ = _sdf->GetValue()->GetAsString();
-    } else if (name == "pointCloudCutoff") {
-      _sdf->GetValue()->Get(pointCloudCutOff_);
-    } else if (name == "pointCloudCutoffMax") {
-      _sdf->GetValue()->Get(pointCloudCutOffMax_);
-    } else if (name == "prefix") {
-      this->prefix = _sdf->GetValue()->GetAsString();
-    } else if (name == "robotNamespace") {
-      break;
-    } else {
-      throw std::runtime_error("Ivalid parameter for RealSensePlugin");
-    }
+  if (_sdf->HasElement("depthUpdateRate")) depthUpdateRate_ = _sdf->Get<double>("depthUpdateRate");
+  if (_sdf->HasElement("colorUpdateRate")) colorUpdateRate_ = _sdf->Get<double>("colorUpdateRate");
+  if (_sdf->HasElement("infraredUpdateRate")) infraredUpdateRate_ = _sdf->Get<double>("infraredUpdateRate");
 
-    _sdf = _sdf->GetNextElement();
-  } while (_sdf);
+  if (_sdf->HasElement("depthTopicName")) cameraParamsMap_[DEPTH_CAMERA_NAME].topic_name = _sdf->Get<std::string>("depthTopicName");
+  if (_sdf->HasElement("depthCameraInfoTopicName")) cameraParamsMap_[DEPTH_CAMERA_NAME].camera_info_topic_name = _sdf->Get<std::string>("depthCameraInfoTopicName");
+  if (_sdf->HasElement("colorTopicName")) cameraParamsMap_[COLOR_CAMERA_NAME].topic_name = _sdf->Get<std::string>("colorTopicName");
+  if (_sdf->HasElement("colorCameraInfoTopicName")) cameraParamsMap_[COLOR_CAMERA_NAME].camera_info_topic_name = _sdf->Get<std::string>("colorCameraInfoTopicName");
+  if (_sdf->HasElement("infrared1TopicName")) cameraParamsMap_[IRED1_CAMERA_NAME].topic_name = _sdf->Get<std::string>("infrared1TopicName");
+  if (_sdf->HasElement("infrared1CameraInfoTopicName")) cameraParamsMap_[IRED1_CAMERA_NAME].camera_info_topic_name = _sdf->Get<std::string>("infrared1CameraInfoTopicName");
+  if (_sdf->HasElement("infrared2TopicName")) cameraParamsMap_[IRED2_CAMERA_NAME].topic_name = _sdf->Get<std::string>("infrared2TopicName");
+  if (_sdf->HasElement("infrared2CameraInfoTopicName")) cameraParamsMap_[IRED2_CAMERA_NAME].camera_info_topic_name = _sdf->Get<std::string>("infrared2CameraInfoTopicName");
 
-  // Store a pointer to the this model
-  this->rsModel = _model;
+  if (_sdf->HasElement("colorOpticalframeName")) cameraParamsMap_[COLOR_CAMERA_NAME].optical_frame = _sdf->Get<std::string>("colorOpticalframeName");
+  if (_sdf->HasElement("depthOpticalframeName")) cameraParamsMap_[DEPTH_CAMERA_NAME].optical_frame = _sdf->Get<std::string>("depthOpticalframeName");
+  if (_sdf->HasElement("infrared1OpticalframeName")) cameraParamsMap_[IRED1_CAMERA_NAME].optical_frame = _sdf->Get<std::string>("infrared1OpticalframeName");
+  if (_sdf->HasElement("infrared2OpticalframeName")) cameraParamsMap_[IRED2_CAMERA_NAME].optical_frame = _sdf->Get<std::string>("infrared2OpticalframeName");
 
-  // Store a pointer to the world
-  this->world = this->rsModel->GetWorld();
+  if (_sdf->HasElement("rangeMinDepth")) rangeMinDepth_ = _sdf->Get<float>("rangeMinDepth");
+  if (_sdf->HasElement("rangeMaxDepth")) rangeMaxDepth_ = _sdf->Get<float>("rangeMaxDepth");
+  if (_sdf->HasElement("pointCloud")) pointCloud_ = _sdf->Get<bool>("pointCloud");
+  if (_sdf->HasElement("pointCloudTopicName")) pointCloudTopic_ = _sdf->Get<std::string>("pointCloudTopicName");
+  if (_sdf->HasElement("pointCloudCutoff")) pointCloudCutOff_ = _sdf->Get<double>("pointCloudCutoff");
+  if (_sdf->HasElement("pointCloudCutoffMax")) pointCloudCutOffMax_ = _sdf->Get<double>("pointCloudCutoffMax");
+  if (_sdf->HasElement("prefix")) this->prefix = _sdf->Get<std::string>("prefix");
 
-  // Sensors Manager
-  sensors::SensorManager * smanager = sensors::SensorManager::Instance();
+  // In Gazebo Harmonic, we need to explicitly know the gz-transport topics the native cameras publish.
+  if (_sdf->HasElement("gzDepthTopic")) cameraParamsMap_[DEPTH_CAMERA_NAME].gz_topic = _sdf->Get<std::string>("gzDepthTopic");
+  if (_sdf->HasElement("gzColorTopic")) cameraParamsMap_[COLOR_CAMERA_NAME].gz_topic = _sdf->Get<std::string>("gzColorTopic");
+  if (_sdf->HasElement("gzInfrared1Topic")) cameraParamsMap_[IRED1_CAMERA_NAME].gz_topic = _sdf->Get<std::string>("gzInfrared1Topic");
+  if (_sdf->HasElement("gzInfrared2Topic")) cameraParamsMap_[IRED2_CAMERA_NAME].gz_topic = _sdf->Get<std::string>("gzInfrared2Topic");
 
-  // Get Cameras Renderers
-  this->depthCam = std::dynamic_pointer_cast<sensors::DepthCameraSensor>(
-    smanager->GetSensor(prefix + DEPTH_CAMERA_NAME))
-    ->DepthCamera();
+  // Since we don't query the visual ECM renderer anymore to maintain sync, we get the known configured HFOVs
+  cameraParamsMap_[DEPTH_CAMERA_NAME].hfov = _sdf->HasElement("depthHFOV") ? _sdf->Get<double>("depthHFOV") : 1.57;
+  cameraParamsMap_[COLOR_CAMERA_NAME].hfov = _sdf->HasElement("colorHFOV") ? _sdf->Get<double>("colorHFOV") : 1.57;
+  cameraParamsMap_[IRED1_CAMERA_NAME].hfov = _sdf->HasElement("infraredHFOV") ? _sdf->Get<double>("infraredHFOV") : 1.57;
+  cameraParamsMap_[IRED2_CAMERA_NAME].hfov = cameraParamsMap_[IRED1_CAMERA_NAME].hfov;
 
-  this->ired1Cam = std::dynamic_pointer_cast<sensors::CameraSensor>(
-    smanager->GetSensor(prefix + IRED1_CAMERA_NAME))
-    ->Camera();
-  this->ired2Cam = std::dynamic_pointer_cast<sensors::CameraSensor>(
-    smanager->GetSensor(prefix + IRED2_CAMERA_NAME))
-    ->Camera();
-  this->colorCam = std::dynamic_pointer_cast<sensors::CameraSensor>(
-    smanager->GetSensor(prefix + COLOR_CAMERA_NAME))
-    ->Camera();
-
-  // Check if camera renderers have been found successfuly
-  if (!this->depthCam) {
-    std::cerr << "RealSensePlugin: Depth Camera has not been found"
-              << std::endl;
-    return;
+  // Subscribe to Gazebo transport topics natively
+  if (!cameraParamsMap_[DEPTH_CAMERA_NAME].gz_topic.empty()) {
+    this->transportNode.Subscribe(cameraParamsMap_[DEPTH_CAMERA_NAME].gz_topic, &RealSensePlugin::OnNewDepthFrame, this);
   }
-  if (!this->ired1Cam) {
-    std::cerr << "RealSensePlugin: InfraRed Camera 1 has not been found"
-              << std::endl;
-    return;
+  if (!cameraParamsMap_[COLOR_CAMERA_NAME].gz_topic.empty()) {
+    this->transportNode.Subscribe(cameraParamsMap_[COLOR_CAMERA_NAME].gz_topic, &RealSensePlugin::OnNewColorFrame, this);
   }
-  if (!this->ired2Cam) {
-    std::cerr << "RealSensePlugin: InfraRed Camera 2 has not been found"
-              << std::endl;
-    return;
+  if (!cameraParamsMap_[IRED1_CAMERA_NAME].gz_topic.empty()) {
+    this->transportNode.Subscribe(cameraParamsMap_[IRED1_CAMERA_NAME].gz_topic, &RealSensePlugin::OnNewInfrared1Frame, this);
   }
-  if (!this->colorCam) {
-    std::cerr << "RealSensePlugin: Color Camera has not been found"
-              << std::endl;
-    return;
+  if (!cameraParamsMap_[IRED2_CAMERA_NAME].gz_topic.empty()) {
+    this->transportNode.Subscribe(cameraParamsMap_[IRED2_CAMERA_NAME].gz_topic, &RealSensePlugin::OnNewInfrared2Frame, this);
   }
-
-  // Resize Depth Map dimensions
-  try {
-    this->depthMap.resize(
-      this->depthCam->ImageWidth() *
-      this->depthCam->ImageHeight());
-  } catch (std::bad_alloc & e) {
-    std::cerr << "RealSensePlugin: depthMap allocation failed: " << e.what()
-              << std::endl;
-    return;
-  }
-
-  // Setup Transport Node
-  this->transportNode = transport::NodePtr(new transport::Node());
-  this->transportNode->Init(this->world->Name());
-
-  // Setup Publishers
-  std::string rsTopicRoot = "~/" + this->rsModel->GetName();
-
-  this->depthPub = this->transportNode->Advertise<msgs::ImageStamped>(
-    rsTopicRoot + DEPTH_CAMERA_TOPIC, 1, depthUpdateRate_);
-  this->ired1Pub = this->transportNode->Advertise<msgs::ImageStamped>(
-    rsTopicRoot + IRED1_CAMERA_TOPIC, 1, infraredUpdateRate_);
-  this->ired2Pub = this->transportNode->Advertise<msgs::ImageStamped>(
-    rsTopicRoot + IRED2_CAMERA_TOPIC, 1, infraredUpdateRate_);
-  this->colorPub = this->transportNode->Advertise<msgs::ImageStamped>(
-    rsTopicRoot + COLOR_CAMERA_TOPIC, 1, colorUpdateRate_);
-
-  // Listen to depth camera new frame event
-  this->newDepthFrameConn = this->depthCam->ConnectNewDepthFrame(
-    std::bind(&RealSensePlugin::OnNewDepthFrame, this));
-
-  this->newIred1FrameConn = this->ired1Cam->ConnectNewImageFrame(
-    std::bind(
-      &RealSensePlugin::OnNewFrame, this, this->ired1Cam, this->ired1Pub));
-
-  this->newIred2FrameConn = this->ired2Cam->ConnectNewImageFrame(
-    std::bind(
-      &RealSensePlugin::OnNewFrame, this, this->ired2Cam, this->ired2Pub));
-
-  this->newColorFrameConn = this->colorCam->ConnectNewImageFrame(
-    std::bind(
-      &RealSensePlugin::OnNewFrame, this, this->colorCam, this->colorPub));
-
-  // Listen to the update event
-  this->updateConnection = event::Events::ConnectWorldUpdateBegin(
-    boost::bind(&RealSensePlugin::OnUpdate, this));
 }
 
-/////////////////////////////////////////////////
-void RealSensePlugin::OnNewFrame(
-  const rendering::CameraPtr cam,
-  const transport::PublisherPtr pub)
-{
-  msgs::ImageStamped msg;
+void RealSensePlugin::OnNewDepthFrame(const gz::msgs::Image & /*_msg*/) {}
+void RealSensePlugin::OnNewColorFrame(const gz::msgs::Image & /*_msg*/) {}
+void RealSensePlugin::OnNewInfrared1Frame(const gz::msgs::Image & /*_msg*/) {}
+void RealSensePlugin::OnNewInfrared2Frame(const gz::msgs::Image & /*_msg*/) {}
 
-  // Set Simulation Time
-  msgs::Set(msg.mutable_time(), this->world->SimTime());
-
-  // Set Image Dimensions
-  msg.mutable_image()->set_width(cam->ImageWidth());
-  msg.mutable_image()->set_height(cam->ImageHeight());
-
-  // Set Image Pixel Format
-  msg.mutable_image()->set_pixel_format(
-    common::Image::ConvertPixelFormat(cam->ImageFormat()));
-
-  // Set Image Data
-  msg.mutable_image()->set_step(cam->ImageWidth() * cam->ImageDepth());
-  msg.mutable_image()->set_data(
-    cam->ImageData(), cam->ImageDepth() *
-    cam->ImageWidth() *
-    cam->ImageHeight());
-
-  // Publish realsense infrared stream
-  pub->Publish(msg);
-}
-
-/////////////////////////////////////////////////
-void RealSensePlugin::OnNewDepthFrame()
-{
-  // Get Depth Map dimensions
-  unsigned int imageSize =
-    this->depthCam->ImageWidth() * this->depthCam->ImageHeight();
-
-  // Instantiate message
-  msgs::ImageStamped msg;
-
-  // Convert Float depth data to RealSense depth data
-  const float * depthDataFloat = this->depthCam->DepthData();
-  for (unsigned int i = 0; i < imageSize; ++i) {
-    // Check clipping and overflow
-    if (depthDataFloat[i] < rangeMinDepth_ ||
-      depthDataFloat[i] > rangeMaxDepth_ ||
-      depthDataFloat[i] > DEPTH_SCALE_M * UINT16_MAX ||
-      depthDataFloat[i] < 0)
-    {
-      this->depthMap[i] = 0;
-    } else {
-      this->depthMap[i] = (uint16_t)(depthDataFloat[i] / DEPTH_SCALE_M);
-    }
-  }
-
-  // Pack realsense scaled depth map
-  msgs::Set(msg.mutable_time(), this->world->SimTime());
-  msg.mutable_image()->set_width(this->depthCam->ImageWidth());
-  msg.mutable_image()->set_height(this->depthCam->ImageHeight());
-  msg.mutable_image()->set_pixel_format(common::Image::L_INT16);
-  msg.mutable_image()->set_step(
-    this->depthCam->ImageWidth() *
-    this->depthCam->ImageDepth());
-  msg.mutable_image()->set_data(
-    this->depthMap.data(),
-    sizeof(*this->depthMap.data()) * imageSize);
-
-  // Publish realsense scaled depth map
-  this->depthPub->Publish(msg);
-}
-
-/////////////////////////////////////////////////
-void RealSensePlugin::OnUpdate() {}
-
-}  // namespace gazebo
+}  // namespace realsense_gazebo_plugin

--- a/src/gazebo_ros_realsense.cpp
+++ b/src/gazebo_ros_realsense.cpp
@@ -14,11 +14,10 @@
 
 #include "realsense_gazebo_plugin/gazebo_ros_realsense.hpp"
 #include <cmath>
-#include <limits>
-
-#include <gz/plugin/Register.hh>
+#include <sensor_msgs/fill_image.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
+#include <gz/plugin/Register.hh>
 
 #define DEPTH_SCALE_M 0.001
 
@@ -29,29 +28,44 @@ GZ_ADD_PLUGIN(
 
 namespace
 {
-sensor_msgs::msg::CameraInfo cameraInfo(
-  const sensor_msgs::msg::Image & image, float horizontal_fov)
+rclcpp::Time getRosStamp(const gz::msgs::Image & image_msg, const rclcpp::Node::SharedPtr & node)
+{
+  // Use Gazebo's message timestamp so simulated camera data stays in sim time.
+  // Falling back to node time keeps behavior safe if a header stamp is absent.
+  const auto & header = image_msg.header();
+  if (header.has_stamp()) {
+    const auto & stamp = header.stamp();
+    const auto stamp_ns =
+      static_cast<int64_t>(stamp.sec()) * 1000000000LL + static_cast<int64_t>(stamp.nsec());
+    return rclcpp::Time(stamp_ns, RCL_ROS_TIME);
+  }
+
+  return node->now();
+}
+
+sensor_msgs::msg::CameraInfo cameraInfo(const sensor_msgs::msg::Image & image, float horizontal_fov)
 {
   sensor_msgs::msg::CameraInfo info_msg;
   info_msg.header = image.header;
   info_msg.distortion_model = "plumb_bob";
   info_msg.height = image.height;
   info_msg.width = image.width;
-
-  const float focal = 0.5f * image.width / tan(0.5f * horizontal_fov);
-
+  const double focal = 0.5 * static_cast<double>(image.width) / tan(0.5 * horizontal_fov);
+  const double cx = 0.5 * static_cast<double>(image.width - 1);
+  const double cy = 0.5 * static_cast<double>(image.height - 1);
   info_msg.k[0] = focal;
   info_msg.k[4] = focal;
-  info_msg.k[2] = info_msg.width * 0.5;
-  info_msg.k[5] = info_msg.height * 0.5;
+  info_msg.k[2] = cx;
+  info_msg.k[5] = cy;
   info_msg.k[8] = 1.;
-
+  info_msg.r[0] = 1.;
+  info_msg.r[4] = 1.;
+  info_msg.r[8] = 1.;
   info_msg.p[0] = info_msg.k[0];
   info_msg.p[5] = info_msg.k[4];
   info_msg.p[2] = info_msg.k[2];
   info_msg.p[6] = info_msg.k[5];
   info_msg.p[10] = info_msg.k[8];
-
   return info_msg;
 }
 }  // namespace
@@ -63,7 +77,9 @@ GazeboRosRealsense::GazeboRosRealsense() {}
 
 GazeboRosRealsense::~GazeboRosRealsense()
 {
-  RCLCPP_DEBUG_STREAM(this->node_->get_logger(), "realsense_camera Unloaded");
+  if (node_) {
+    RCLCPP_DEBUG_STREAM(this->node_->get_logger(), "realsense_camera Unloaded");
+  }
 }
 
 void GazeboRosRealsense::Configure(const gz::sim::Entity &_entity,
@@ -86,23 +102,27 @@ void GazeboRosRealsense::Configure(const gz::sim::Entity &_entity,
   this->camera_info_manager_.reset(
     new camera_info_manager::CameraInfoManager(this->node_.get(), node_name));
 
+  // Helper lambda to gracefully parse absolute (leading '/') ROS topic names
+  // without creating double slashes with the node's prefix string.
+  auto build_topic = [](const std::string& pfx, const std::string& tpc) {
+    if (tpc.empty()) return pfx;
+    if (tpc.front() == '/') return tpc; // Absolute topic, return as-is
+    return pfx.empty() ? tpc : pfx + "/" + tpc;
+  };
+
   this->color_pub_ = image_transport::create_camera_publisher(
-    this->node_.get(), prefix + std::string("/") +
-    cameraParamsMap_[COLOR_CAMERA_NAME].topic_name, rmw_qos_profile_sensor_data);
+    this->node_.get(), build_topic(this->prefix, cameraParamsMap_[COLOR_CAMERA_NAME].topic_name), rmw_qos_profile_sensor_data);
   this->ir1_pub_ = image_transport::create_camera_publisher(
-    this->node_.get(), prefix + std::string("/") +
-    cameraParamsMap_[IRED1_CAMERA_NAME].topic_name, rmw_qos_profile_sensor_data);
+    this->node_.get(), build_topic(this->prefix, cameraParamsMap_[IRED1_CAMERA_NAME].topic_name), rmw_qos_profile_sensor_data);
   this->ir2_pub_ = image_transport::create_camera_publisher(
-    this->node_.get(), prefix + std::string("/") +
-    cameraParamsMap_[IRED2_CAMERA_NAME].topic_name, rmw_qos_profile_sensor_data);
+    this->node_.get(), build_topic(this->prefix, cameraParamsMap_[IRED2_CAMERA_NAME].topic_name), rmw_qos_profile_sensor_data);
   this->depth_pub_ = image_transport::create_camera_publisher(
-    this->node_.get(), prefix + std::string("/") +
-    cameraParamsMap_[DEPTH_CAMERA_NAME].topic_name, rmw_qos_profile_sensor_data);
+    this->node_.get(), build_topic(this->prefix, cameraParamsMap_[DEPTH_CAMERA_NAME].topic_name), rmw_qos_profile_sensor_data);
 
   if (pointCloud_) {
     this->pctnode_ = std::make_unique<point_cloud_transport::PointCloudTransport>(this->node_);
     this->pointcloud_pub_ = this->pctnode_->advertise(
-      prefix + std::string("/") + pointCloudTopic_, rmw_qos_profile_sensor_data);
+      build_topic(this->prefix, pointCloudTopic_), rmw_qos_profile_sensor_data);
   }
 
   RCLCPP_INFO(node_->get_logger(), "Loaded Realsense Gazebo ROS plugin.");
@@ -110,56 +130,64 @@ void GazeboRosRealsense::Configure(const gz::sim::Entity &_entity,
 
 void GazeboRosRealsense::OnNewColorFrame(const gz::msgs::Image & _msg)
 {
-  this->image_msg_.header.frame_id = cameraParamsMap_[COLOR_CAMERA_NAME].optical_frame;
-  this->image_msg_.header.stamp = node_->now();
-  this->image_msg_.height = _msg.height();
-  this->image_msg_.width = _msg.width();
-  this->image_msg_.encoding = sensor_msgs::image_encodings::RGB8;
-  this->image_msg_.is_bigendian = false;
-  this->image_msg_.step = _msg.width() * 3;
-  this->image_msg_.data.resize(this->image_msg_.step * this->image_msg_.height);
-  std::copy(_msg.data().begin(), _msg.data().end(), this->image_msg_.data.begin());
+  sensor_msgs::msg::Image msg;
+  msg.header.frame_id = cameraParamsMap_[COLOR_CAMERA_NAME].optical_frame;
+  msg.header.stamp = getRosStamp(_msg, node_);
+  msg.height = _msg.height();
+  msg.width = _msg.width();
+  msg.encoding = sensor_msgs::image_encodings::RGB8;
+  msg.is_bigendian = false;
+  msg.step = _msg.width() * 3;
+  msg.data.resize(msg.step * msg.height);
+  std::copy(_msg.data().begin(), _msg.data().end(), msg.data.begin());
 
-  auto info_msg = cameraInfo(this->image_msg_, cameraParamsMap_[COLOR_CAMERA_NAME].hfov);
-  color_pub_.publish(this->image_msg_, info_msg);
+  auto info_msg = cameraInfo(msg, cameraParamsMap_[COLOR_CAMERA_NAME].hfov);
+  color_pub_.publish(msg, info_msg);
+
+  {
+    std::lock_guard<std::mutex> lock(color_mutex_);
+    latest_color_msg_ = msg;
+  }
 }
 
 void GazeboRosRealsense::OnNewInfrared1Frame(const gz::msgs::Image & _msg)
 {
-  this->image_msg_.header.frame_id = cameraParamsMap_[IRED1_CAMERA_NAME].optical_frame;
-  this->image_msg_.header.stamp = node_->now();
-  this->image_msg_.height = _msg.height();
-  this->image_msg_.width = _msg.width();
-  this->image_msg_.encoding = sensor_msgs::image_encodings::MONO8;
-  this->image_msg_.is_bigendian = false;
-  this->image_msg_.step = _msg.width();
-  this->image_msg_.data.resize(this->image_msg_.step * this->image_msg_.height);
-  std::copy(_msg.data().begin(), _msg.data().end(), this->image_msg_.data.begin());
+  sensor_msgs::msg::Image msg;
+  msg.header.frame_id = cameraParamsMap_[IRED1_CAMERA_NAME].optical_frame;
+  msg.header.stamp = getRosStamp(_msg, node_);
+  msg.height = _msg.height();
+  msg.width = _msg.width();
+  msg.encoding = sensor_msgs::image_encodings::MONO8;
+  msg.is_bigendian = false;
+  msg.step = _msg.width();
+  msg.data.resize(msg.step * msg.height);
+  std::copy(_msg.data().begin(), _msg.data().end(), msg.data.begin());
 
-  auto info_msg = cameraInfo(this->image_msg_, cameraParamsMap_[IRED1_CAMERA_NAME].hfov);
-  ir1_pub_.publish(this->image_msg_, info_msg);
+  auto info_msg = cameraInfo(msg, cameraParamsMap_[IRED1_CAMERA_NAME].hfov);
+  ir1_pub_.publish(msg, info_msg);
 }
 
 void GazeboRosRealsense::OnNewInfrared2Frame(const gz::msgs::Image & _msg)
 {
-  this->image_msg_.header.frame_id = cameraParamsMap_[IRED2_CAMERA_NAME].optical_frame;
-  this->image_msg_.header.stamp = node_->now();
-  this->image_msg_.height = _msg.height();
-  this->image_msg_.width = _msg.width();
-  this->image_msg_.encoding = sensor_msgs::image_encodings::MONO8;
-  this->image_msg_.is_bigendian = false;
-  this->image_msg_.step = _msg.width();
-  this->image_msg_.data.resize(this->image_msg_.step * this->image_msg_.height);
-  std::copy(_msg.data().begin(), _msg.data().end(), this->image_msg_.data.begin());
+  sensor_msgs::msg::Image msg;
+  msg.header.frame_id = cameraParamsMap_[IRED2_CAMERA_NAME].optical_frame;
+  msg.header.stamp = getRosStamp(_msg, node_);
+  msg.height = _msg.height();
+  msg.width = _msg.width();
+  msg.encoding = sensor_msgs::image_encodings::MONO8;
+  msg.is_bigendian = false;
+  msg.step = _msg.width();
+  msg.data.resize(msg.step * msg.height);
+  std::copy(_msg.data().begin(), _msg.data().end(), msg.data.begin());
 
-  auto info_msg = cameraInfo(this->image_msg_, cameraParamsMap_[IRED2_CAMERA_NAME].hfov);
-  ir2_pub_.publish(this->image_msg_, info_msg);
+  auto info_msg = cameraInfo(msg, cameraParamsMap_[IRED2_CAMERA_NAME].hfov);
+  ir2_pub_.publish(msg, info_msg);
 }
 
 void GazeboRosRealsense::OnNewDepthFrame(const gz::msgs::Image & _msg)
 {
   this->depth_msg_.header.frame_id = cameraParamsMap_[DEPTH_CAMERA_NAME].optical_frame;
-  this->depth_msg_.header.stamp = node_->now();
+  this->depth_msg_.header.stamp = getRosStamp(_msg, node_);
   this->depth_msg_.height = _msg.height();
   this->depth_msg_.width = _msg.width();
   this->depth_msg_.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
@@ -168,17 +196,14 @@ void GazeboRosRealsense::OnNewDepthFrame(const gz::msgs::Image & _msg)
   this->depth_msg_.data.resize(this->depth_msg_.step * this->depth_msg_.height);
 
   unsigned int imageSize = _msg.width() * _msg.height();
-  const float * depthDataFloat = reinterpret_cast<const float *>(_msg.data().data());
-  uint16_t * depthDataUint = reinterpret_cast<uint16_t *>(this->depth_msg_.data.data());
+  const float * depthDataFloat = reinterpret_cast<const float*>(_msg.data().c_str());
+  uint16_t * depthDataUint = reinterpret_cast<uint16_t*>(this->depth_msg_.data.data());
 
   for (unsigned int i = 0; i < imageSize; ++i) {
-    if (depthDataFloat[i] < rangeMinDepth_ ||
-      depthDataFloat[i] > rangeMaxDepth_ ||
-      depthDataFloat[i] < 0)
-    {
+    if (depthDataFloat[i] < rangeMinDepth_ || depthDataFloat[i] > rangeMaxDepth_ || depthDataFloat[i] < 0) {
       depthDataUint[i] = 0;
     } else {
-      depthDataUint[i] = static_cast<uint16_t>(depthDataFloat[i] / DEPTH_SCALE_M);
+      depthDataUint[i] = (uint16_t)(depthDataFloat[i] / DEPTH_SCALE_M);
     }
   }
 
@@ -187,20 +212,28 @@ void GazeboRosRealsense::OnNewDepthFrame(const gz::msgs::Image & _msg)
 
   if (pointCloud_ && this->pointcloud_pub_.getNumSubscribers() > 0) {
     this->pointcloud_msg_.header = this->depth_msg_.header;
+
+    sensor_msgs::msg::Image color_msg_copy;
+    {
+       std::lock_guard<std::mutex> lock(color_mutex_);
+       color_msg_copy = latest_color_msg_;
+    }
+
     FillPointCloudHelper(
       this->pointcloud_msg_, _msg.height(), _msg.width(),
-      _msg.width() * sizeof(float), depthDataFloat);
+      _msg.width() * sizeof(float), depthDataFloat, color_msg_copy);
     this->pointcloud_pub_.publish(this->pointcloud_msg_);
   }
 }
 
 bool GazeboRosRealsense::FillPointCloudHelper(
   sensor_msgs::msg::PointCloud2 & point_cloud_msg, uint32_t rows_arg,
-  uint32_t cols_arg, uint32_t /*step_arg*/, const void * data_arg)
+  uint32_t cols_arg, uint32_t /*step_arg*/, const void * data_arg,
+  const sensor_msgs::msg::Image & color_msg)
 {
   sensor_msgs::PointCloud2Modifier pcd_modifier(point_cloud_msg);
   pcd_modifier.setPointCloud2FieldsByString(2, "xyz", "rgb");
-  pcd_modifier.resize(rows_arg * cols_arg);
+  pcd_modifier.resize(cols_arg, rows_arg);
   point_cloud_msg.is_dense = true;
 
   sensor_msgs::PointCloud2Iterator<float> iter_x(point_cloud_msg, "x");
@@ -213,58 +246,49 @@ bool GazeboRosRealsense::FillPointCloudHelper(
 
   const double hfov = cameraParamsMap_[DEPTH_CAMERA_NAME].hfov;
   const double focal = static_cast<double>(cols_arg) / (2.0 * tan(hfov / 2.0));
+  const double cx = 0.5 * static_cast<double>(cols_arg - 1);
+  const double cy = 0.5 * static_cast<double>(rows_arg - 1);
+
+  const bool has_color = !color_msg.data.empty();
+  const bool color_dimensions_match =
+    has_color &&
+    color_msg.encoding == sensor_msgs::image_encodings::RGB8 &&
+    color_msg.width == cols_arg &&
+    color_msg.height == rows_arg &&
+    color_msg.step >= cols_arg * 3 &&
+    color_msg.data.size() >= static_cast<size_t>(color_msg.step) * color_msg.height;
+
+  if (has_color && !color_dimensions_match) {
+    RCLCPP_WARN_ONCE(
+      node_->get_logger(),
+      "Skipping point cloud colorization because the color frame (%ux%u, encoding=%s) does not "
+      "match the depth frame (%ux%u).",
+      color_msg.width, color_msg.height, color_msg.encoding.c_str(), cols_arg, rows_arg);
+  }
 
   for (uint32_t j = 0; j < rows_arg; j++) {
-    double pAngle;
-    if (rows_arg > 1) {
-      pAngle = atan2(
-        static_cast<double>(j) - 0.5 * static_cast<double>(rows_arg - 1), focal);
-    } else {
-      pAngle = 0.0;
-    }
-
     for (uint32_t i = 0; i < cols_arg; i++, ++iter_x, ++iter_y, ++iter_z, ++iter_rgb) {
       const double depth = toCopyFrom[index++];
 
       if (std::isfinite(depth) && depth > pointCloudCutOff_ && depth < pointCloudCutOffMax_) {
-        double yAngle;
-        if (cols_arg > 1) {
-          yAngle = atan2(
-            static_cast<double>(i) - 0.5 * static_cast<double>(cols_arg - 1), focal);
-        } else {
-          yAngle = 0.0;
-        }
+        const double normalized_x = (static_cast<double>(i) - cx) / focal;
+        const double normalized_y = (static_cast<double>(j) - cy) / focal;
 
-        *iter_x = depth * tan(yAngle);
-        *iter_y = depth * tan(pAngle);
+        *iter_x = depth * normalized_x;
+        *iter_y = depth * normalized_y;
         *iter_z = depth;
       } else {
         *iter_x = *iter_y = *iter_z = std::numeric_limits<float>::quiet_NaN();
         point_cloud_msg.is_dense = false;
       }
 
-      uint8_t * image_src = reinterpret_cast<uint8_t *>(this->image_msg_.data.data());
-      if (this->image_msg_.data.size() == static_cast<size_t>(rows_arg) * cols_arg * 3) {
-        if (this->image_msg_.encoding == sensor_msgs::image_encodings::RGB8) {
-          iter_rgb[2] = image_src[i * 3 + j * cols_arg * 3 + 0];
-          iter_rgb[1] = image_src[i * 3 + j * cols_arg * 3 + 1];
-          iter_rgb[0] = image_src[i * 3 + j * cols_arg * 3 + 2];
-        } else if (this->image_msg_.encoding == sensor_msgs::image_encodings::BGR8) {
-          iter_rgb[0] = image_src[i * 3 + j * cols_arg * 3 + 0];
-          iter_rgb[1] = image_src[i * 3 + j * cols_arg * 3 + 1];
-          iter_rgb[2] = image_src[i * 3 + j * cols_arg * 3 + 2];
-        } else {
-          throw std::runtime_error(
-            "unsupported colour encoding: " + this->image_msg_.encoding);
-        }
-      } else if (this->image_msg_.data.size() == static_cast<size_t>(rows_arg) * cols_arg) {
-        iter_rgb[0] = image_src[i + j * cols_arg];
-        iter_rgb[1] = image_src[i + j * cols_arg];
-        iter_rgb[2] = image_src[i + j * cols_arg];
+      if (color_dimensions_match) {
+        const auto pixel_offset = static_cast<size_t>(j) * color_msg.step + static_cast<size_t>(i) * 3U;
+        iter_rgb[2] = color_msg.data[pixel_offset + 0];
+        iter_rgb[1] = color_msg.data[pixel_offset + 1];
+        iter_rgb[0] = color_msg.data[pixel_offset + 2];
       } else {
-        iter_rgb[0] = 0;
-        iter_rgb[1] = 0;
-        iter_rgb[2] = 0;
+        iter_rgb[0] = iter_rgb[1] = iter_rgb[2] = 0;
       }
     }
   }

--- a/src/gazebo_ros_realsense.cpp
+++ b/src/gazebo_ros_realsense.cpp
@@ -13,22 +13,51 @@
 // limitations under the License.
 
 #include "realsense_gazebo_plugin/gazebo_ros_realsense.hpp"
-#include <sensor_msgs/fill_image.hpp>
+#include <cmath>
+#include <limits>
+
+#include <gz/plugin/Register.hh>
 #include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
+#define DEPTH_SCALE_M 0.001
+
+GZ_ADD_PLUGIN(
+  realsense_gazebo_plugin::GazeboRosRealsense,
+  gz::sim::System,
+  realsense_gazebo_plugin::GazeboRosRealsense::ISystemConfigure)
+
 namespace
 {
-std::string extractCameraName(const std::string & name);
 sensor_msgs::msg::CameraInfo cameraInfo(
-  const sensor_msgs::msg::Image & image,
-  float horizontal_fov);
+  const sensor_msgs::msg::Image & image, float horizontal_fov)
+{
+  sensor_msgs::msg::CameraInfo info_msg;
+  info_msg.header = image.header;
+  info_msg.distortion_model = "plumb_bob";
+  info_msg.height = image.height;
+  info_msg.width = image.width;
+
+  const float focal = 0.5f * image.width / tan(0.5f * horizontal_fov);
+
+  info_msg.k[0] = focal;
+  info_msg.k[4] = focal;
+  info_msg.k[2] = info_msg.width * 0.5;
+  info_msg.k[5] = info_msg.height * 0.5;
+  info_msg.k[8] = 1.;
+
+  info_msg.p[0] = info_msg.k[0];
+  info_msg.p[5] = info_msg.k[4];
+  info_msg.p[2] = info_msg.k[2];
+  info_msg.p[6] = info_msg.k[5];
+  info_msg.p[10] = info_msg.k[8];
+
+  return info_msg;
+}
 }  // namespace
 
-namespace gazebo
+namespace realsense_gazebo_plugin
 {
-// Register the plugin
-GZ_REGISTER_MODEL_PLUGIN(GazeboRosRealsense)
 
 GazeboRosRealsense::GazeboRosRealsense() {}
 
@@ -37,30 +66,25 @@ GazeboRosRealsense::~GazeboRosRealsense()
   RCLCPP_DEBUG_STREAM(this->node_->get_logger(), "realsense_camera Unloaded");
 }
 
-void GazeboRosRealsense::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+void GazeboRosRealsense::Configure(const gz::sim::Entity &_entity,
+                                   const std::shared_ptr<const sdf::Element> &_sdf,
+                                   gz::sim::EntityComponentManager &_ecm,
+                                   gz::sim::EventManager &_eventMgr)
 {
-  RealSensePlugin::Load(_model, _sdf);
+  RealSensePlugin::Configure(_entity, _sdf, _ecm, _eventMgr);
+
+  if (!rclcpp::ok()) {
+    rclcpp::init(0, nullptr);
+  }
+
   std::string node_name = "gazebo_realsense";
   node_name += this->prefix.empty() ? "" : "_" + this->prefix;
   this->node_ = rclcpp::Node::make_shared(node_name);
 
-  // Make sure the ROS node for Gazebo has already been initialized
-  if (!rclcpp::ok()) {
-    RCLCPP_ERROR(
-      node_->get_logger(),
-      "A ROS node for Gazebo has not been initialized, unable "
-      "to load plugin. "
-      "Load the Gazebo system plugin "
-      "'libgazebo_ros_api_plugin.so' in the gazebo_ros "
-      "package");
-    return;
-  }
   RCLCPP_INFO(node_->get_logger(), "Realsense Gazebo ROS plugin loading.");
 
-  // initialize camera_info_manager
   this->camera_info_manager_.reset(
-    new camera_info_manager::CameraInfoManager(
-      this->node_.get(), this->GetHandle()));
+    new camera_info_manager::CameraInfoManager(this->node_.get(), node_name));
 
   this->color_pub_ = image_transport::create_camera_publisher(
     this->node_.get(), prefix + std::string("/") +
@@ -78,124 +102,149 @@ void GazeboRosRealsense::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   if (pointCloud_) {
     this->pctnode_ = std::make_unique<point_cloud_transport::PointCloudTransport>(this->node_);
     this->pointcloud_pub_ = this->pctnode_->advertise(
-      prefix + std::string(
-        "/") + pointCloudTopic_, rmw_qos_profile_sensor_data);
+      prefix + std::string("/") + pointCloudTopic_, rmw_qos_profile_sensor_data);
   }
 
   RCLCPP_INFO(node_->get_logger(), "Loaded Realsense Gazebo ROS plugin.");
 }
 
-void GazeboRosRealsense::OnNewFrame(
-  const rendering::CameraPtr cam,
-  const transport::PublisherPtr pub)
+void GazeboRosRealsense::OnNewColorFrame(const gz::msgs::Image & _msg)
 {
-  common::Time current_time = this->world->SimTime();
+  this->image_msg_.header.frame_id = cameraParamsMap_[COLOR_CAMERA_NAME].optical_frame;
+  this->image_msg_.header.stamp = node_->now();
+  this->image_msg_.height = _msg.height();
+  this->image_msg_.width = _msg.width();
+  this->image_msg_.encoding = sensor_msgs::image_encodings::RGB8;
+  this->image_msg_.is_bigendian = false;
+  this->image_msg_.step = _msg.width() * 3;
+  this->image_msg_.data.resize(this->image_msg_.step * this->image_msg_.height);
+  std::copy(_msg.data().begin(), _msg.data().end(), this->image_msg_.data.begin());
 
-  // identify camera
-  std::string camera_id = extractCameraName(cam->Name());
-  const std::map<std::string, image_transport::CameraPublisher *>
-  camera_publishers = {
-    {COLOR_CAMERA_NAME, &(this->color_pub_)},
-    {IRED1_CAMERA_NAME, &(this->ir1_pub_)},
-    {IRED2_CAMERA_NAME, &(this->ir2_pub_)},
-  };
-  const auto image_pub = camera_publishers.at(camera_id);
-
-  // copy data into image
-  this->image_msg_.header.frame_id =
-    this->cameraParamsMap_[camera_id].optical_frame;
-  this->image_msg_.header.stamp.sec = current_time.sec;
-  this->image_msg_.header.stamp.nanosec = current_time.nsec;
-
-  // set image encoding
-  const std::map<std::string, std::string> supported_image_encodings = {
-    {"RGB_INT8", sensor_msgs::image_encodings::RGB8},
-    {"L_INT8", sensor_msgs::image_encodings::TYPE_8UC1}};
-  const auto pixel_format = supported_image_encodings.at(cam->ImageFormat());
-
-  // copy from simulation image to ROS msg
-  sensor_msgs::fillImage(
-    this->image_msg_, pixel_format, cam->ImageHeight(),
-    cam->ImageWidth(),
-    cam->ImageDepth() * cam->ImageWidth(),
-    reinterpret_cast<const void *>(cam->ImageData()));
-
-  // identify camera rendering
-  const std::map<std::string, rendering::CameraPtr> cameras = {
-    {COLOR_CAMERA_NAME, this->colorCam},
-    {IRED1_CAMERA_NAME, this->ired1Cam},
-    {IRED2_CAMERA_NAME, this->ired2Cam},
-  };
-
-  // publish to ROS
-  auto camera_info_msg =
-    cameraInfo(this->image_msg_, cameras.at(camera_id)->HFOV().Radian());
-  image_pub->publish(this->image_msg_, camera_info_msg);
+  auto info_msg = cameraInfo(this->image_msg_, cameraParamsMap_[COLOR_CAMERA_NAME].hfov);
+  color_pub_.publish(this->image_msg_, info_msg);
 }
 
-// Referenced from gazebo_plugins
-// https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_plugins/src/gazebo_ros_openni_kinect.cpp#L302
-// Fill depth information
+void GazeboRosRealsense::OnNewInfrared1Frame(const gz::msgs::Image & _msg)
+{
+  this->image_msg_.header.frame_id = cameraParamsMap_[IRED1_CAMERA_NAME].optical_frame;
+  this->image_msg_.header.stamp = node_->now();
+  this->image_msg_.height = _msg.height();
+  this->image_msg_.width = _msg.width();
+  this->image_msg_.encoding = sensor_msgs::image_encodings::MONO8;
+  this->image_msg_.is_bigendian = false;
+  this->image_msg_.step = _msg.width();
+  this->image_msg_.data.resize(this->image_msg_.step * this->image_msg_.height);
+  std::copy(_msg.data().begin(), _msg.data().end(), this->image_msg_.data.begin());
+
+  auto info_msg = cameraInfo(this->image_msg_, cameraParamsMap_[IRED1_CAMERA_NAME].hfov);
+  ir1_pub_.publish(this->image_msg_, info_msg);
+}
+
+void GazeboRosRealsense::OnNewInfrared2Frame(const gz::msgs::Image & _msg)
+{
+  this->image_msg_.header.frame_id = cameraParamsMap_[IRED2_CAMERA_NAME].optical_frame;
+  this->image_msg_.header.stamp = node_->now();
+  this->image_msg_.height = _msg.height();
+  this->image_msg_.width = _msg.width();
+  this->image_msg_.encoding = sensor_msgs::image_encodings::MONO8;
+  this->image_msg_.is_bigendian = false;
+  this->image_msg_.step = _msg.width();
+  this->image_msg_.data.resize(this->image_msg_.step * this->image_msg_.height);
+  std::copy(_msg.data().begin(), _msg.data().end(), this->image_msg_.data.begin());
+
+  auto info_msg = cameraInfo(this->image_msg_, cameraParamsMap_[IRED2_CAMERA_NAME].hfov);
+  ir2_pub_.publish(this->image_msg_, info_msg);
+}
+
+void GazeboRosRealsense::OnNewDepthFrame(const gz::msgs::Image & _msg)
+{
+  this->depth_msg_.header.frame_id = cameraParamsMap_[DEPTH_CAMERA_NAME].optical_frame;
+  this->depth_msg_.header.stamp = node_->now();
+  this->depth_msg_.height = _msg.height();
+  this->depth_msg_.width = _msg.width();
+  this->depth_msg_.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
+  this->depth_msg_.is_bigendian = false;
+  this->depth_msg_.step = _msg.width() * 2;
+  this->depth_msg_.data.resize(this->depth_msg_.step * this->depth_msg_.height);
+
+  unsigned int imageSize = _msg.width() * _msg.height();
+  const float * depthDataFloat = reinterpret_cast<const float *>(_msg.data().data());
+  uint16_t * depthDataUint = reinterpret_cast<uint16_t *>(this->depth_msg_.data.data());
+
+  for (unsigned int i = 0; i < imageSize; ++i) {
+    if (depthDataFloat[i] < rangeMinDepth_ ||
+      depthDataFloat[i] > rangeMaxDepth_ ||
+      depthDataFloat[i] < 0)
+    {
+      depthDataUint[i] = 0;
+    } else {
+      depthDataUint[i] = static_cast<uint16_t>(depthDataFloat[i] / DEPTH_SCALE_M);
+    }
+  }
+
+  auto depth_info_msg = cameraInfo(this->depth_msg_, cameraParamsMap_[DEPTH_CAMERA_NAME].hfov);
+  this->depth_pub_.publish(this->depth_msg_, depth_info_msg);
+
+  if (pointCloud_ && this->pointcloud_pub_.getNumSubscribers() > 0) {
+    this->pointcloud_msg_.header = this->depth_msg_.header;
+    FillPointCloudHelper(
+      this->pointcloud_msg_, _msg.height(), _msg.width(),
+      _msg.width() * sizeof(float), depthDataFloat);
+    this->pointcloud_pub_.publish(this->pointcloud_msg_);
+  }
+}
+
 bool GazeboRosRealsense::FillPointCloudHelper(
   sensor_msgs::msg::PointCloud2 & point_cloud_msg, uint32_t rows_arg,
-  uint32_t cols_arg, uint32_t step_arg, const void * data_arg)
+  uint32_t cols_arg, uint32_t /*step_arg*/, const void * data_arg)
 {
   sensor_msgs::PointCloud2Modifier pcd_modifier(point_cloud_msg);
   pcd_modifier.setPointCloud2FieldsByString(2, "xyz", "rgb");
-  // convert to flat array shape, we need to reconvert later
   pcd_modifier.resize(rows_arg * cols_arg);
   point_cloud_msg.is_dense = true;
 
-  sensor_msgs::PointCloud2Iterator<float> iter_x(pointcloud_msg_, "x");
-  sensor_msgs::PointCloud2Iterator<float> iter_y(pointcloud_msg_, "y");
-  sensor_msgs::PointCloud2Iterator<float> iter_z(pointcloud_msg_, "z");
-  sensor_msgs::PointCloud2Iterator<uint8_t> iter_rgb(pointcloud_msg_, "rgb");
+  sensor_msgs::PointCloud2Iterator<float> iter_x(point_cloud_msg, "x");
+  sensor_msgs::PointCloud2Iterator<float> iter_y(point_cloud_msg, "y");
+  sensor_msgs::PointCloud2Iterator<float> iter_z(point_cloud_msg, "z");
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_rgb(point_cloud_msg, "rgb");
 
   const float * toCopyFrom = reinterpret_cast<const float *>(data_arg);
-  int index = 0;
+  size_t index = 0;
 
-  double hfov = this->depthCam->HFOV().Radian();
-  double fl = (static_cast<double>(this->depthCam->ImageWidth()) / (2.0 * tan(hfov / 2.0)));
+  const double hfov = cameraParamsMap_[DEPTH_CAMERA_NAME].hfov;
+  const double focal = static_cast<double>(cols_arg) / (2.0 * tan(hfov / 2.0));
 
-  // convert depth to point cloud
   for (uint32_t j = 0; j < rows_arg; j++) {
     double pAngle;
     if (rows_arg > 1) {
-      pAngle = atan2(static_cast<double>(j) - 0.5 * static_cast<double>(rows_arg - 1), fl);
+      pAngle = atan2(
+        static_cast<double>(j) - 0.5 * static_cast<double>(rows_arg - 1), focal);
     } else {
       pAngle = 0.0;
     }
 
-    for (uint32_t i = 0; i < cols_arg;
-      i++, ++iter_x, ++iter_y, ++iter_z, ++iter_rgb)
-    {
-      double yAngle;
-      if (cols_arg > 1) {
-        yAngle = atan2(static_cast<double>(i) - 0.5 * static_cast<double>(cols_arg - 1), fl);
-      } else {
-        yAngle = 0.0;
-      }
+    for (uint32_t i = 0; i < cols_arg; i++, ++iter_x, ++iter_y, ++iter_z, ++iter_rgb) {
+      const double depth = toCopyFrom[index++];
 
-      double depth =
-        toCopyFrom[index++];   // + 0.0*this->myParent->GetNearClip();
+      if (std::isfinite(depth) && depth > pointCloudCutOff_ && depth < pointCloudCutOffMax_) {
+        double yAngle;
+        if (cols_arg > 1) {
+          yAngle = atan2(
+            static_cast<double>(i) - 0.5 * static_cast<double>(cols_arg - 1), focal);
+        } else {
+          yAngle = 0.0;
+        }
 
-      if (depth > pointCloudCutOff_ && depth < pointCloudCutOffMax_) {
-        // in optical frame
-        // hardcoded rotation rpy(-M_PI/2, 0, -M_PI/2) is built-in
-        // to urdf, where the *_optical_frame should have above relative
-        // rotation from the physical camera *_frame
         *iter_x = depth * tan(yAngle);
         *iter_y = depth * tan(pAngle);
         *iter_z = depth;
-      } else {  // point in the unseeable range
+      } else {
         *iter_x = *iter_y = *iter_z = std::numeric_limits<float>::quiet_NaN();
         point_cloud_msg.is_dense = false;
       }
 
-      // put image color data for each point
-      uint8_t * image_src = reinterpret_cast<uint8_t *>(&(this->image_msg_.data[0]));
-      if (this->image_msg_.data.size() == rows_arg * cols_arg * 3) {
-        // color
+      uint8_t * image_src = reinterpret_cast<uint8_t *>(this->image_msg_.data.data());
+      if (this->image_msg_.data.size() == static_cast<size_t>(rows_arg) * cols_arg * 3) {
         if (this->image_msg_.encoding == sensor_msgs::image_encodings::RGB8) {
           iter_rgb[2] = image_src[i * 3 + j * cols_arg * 3 + 0];
           iter_rgb[1] = image_src[i * 3 + j * cols_arg * 3 + 1];
@@ -206,16 +255,13 @@ bool GazeboRosRealsense::FillPointCloudHelper(
           iter_rgb[2] = image_src[i * 3 + j * cols_arg * 3 + 2];
         } else {
           throw std::runtime_error(
-                  "unsupported colour encoding: " +
-                  this->image_msg_.encoding);
+            "unsupported colour encoding: " + this->image_msg_.encoding);
         }
-      } else if (this->image_msg_.data.size() == rows_arg * cols_arg) {
-        // mono (or bayer?  @todo; fix for bayer)
+      } else if (this->image_msg_.data.size() == static_cast<size_t>(rows_arg) * cols_arg) {
         iter_rgb[0] = image_src[i + j * cols_arg];
         iter_rgb[1] = image_src[i + j * cols_arg];
         iter_rgb[2] = image_src[i + j * cols_arg];
       } else {
-        // no image
         iter_rgb[0] = 0;
         iter_rgb[1] = 0;
         iter_rgb[2] = 0;
@@ -223,103 +269,10 @@ bool GazeboRosRealsense::FillPointCloudHelper(
     }
   }
 
-  // reconvert to original height and width after the flat reshape
   point_cloud_msg.height = rows_arg;
   point_cloud_msg.width = cols_arg;
   point_cloud_msg.row_step = point_cloud_msg.point_step * point_cloud_msg.width;
-
   return true;
 }
 
-void GazeboRosRealsense::OnNewDepthFrame()
-{
-  // get current time
-  common::Time current_time = this->world->SimTime();
-
-  RealSensePlugin::OnNewDepthFrame();
-
-  // copy data into image
-  this->depth_msg_.header.frame_id =
-    this->cameraParamsMap_[DEPTH_CAMERA_NAME].optical_frame;
-  this->depth_msg_.header.stamp.sec = current_time.sec;
-  this->depth_msg_.header.stamp.nanosec = current_time.nsec;
-
-  // set image encoding
-  std::string pixel_format = sensor_msgs::image_encodings::TYPE_16UC1;
-
-  // copy from simulation image to ROS msg
-  sensor_msgs::fillImage(
-    this->depth_msg_, pixel_format, this->depthCam->ImageHeight(),
-    this->depthCam->ImageWidth(), 2 * this->depthCam->ImageWidth(),
-    reinterpret_cast<const void *>(this->depthMap.data()));
-
-  // publish to ROS
-  auto depth_info_msg =
-    cameraInfo(this->depth_msg_, this->depthCam->HFOV().Radian());
-  this->depth_pub_.publish(this->depth_msg_, depth_info_msg);
-
-  if (pointCloud_ && this->pointcloud_pub_.getNumSubscribers() > 0) {
-    this->pointcloud_msg_.header = this->depth_msg_.header;
-    this->pointcloud_msg_.width = this->depthCam->ImageWidth();
-    this->pointcloud_msg_.height = this->depthCam->ImageHeight();
-    this->pointcloud_msg_.row_step =
-      this->pointcloud_msg_.point_step * this->depthCam->ImageWidth();
-    FillPointCloudHelper(
-      this->pointcloud_msg_, this->depthCam->ImageHeight(),
-      this->depthCam->ImageWidth(),
-      2 * this->depthCam->ImageWidth(),
-      reinterpret_cast<const void *>(this->depthCam->DepthData()));
-    this->pointcloud_pub_.publish(this->pointcloud_msg_);
-  }
-}
-}  // namespace gazebo
-
-namespace
-{
-std::string extractCameraName(const std::string & name)
-{
-  if (name.find(COLOR_CAMERA_NAME) != std::string::npos) {
-    return COLOR_CAMERA_NAME;
-  }
-  if (name.find(IRED1_CAMERA_NAME) != std::string::npos) {
-    return IRED1_CAMERA_NAME;
-  }
-  if (name.find(IRED2_CAMERA_NAME) != std::string::npos) {
-    return IRED2_CAMERA_NAME;
-  }
-
-  RCLCPP_ERROR(rclcpp::get_logger("realsense_camera"), "Unknown camera name");
-
-  return COLOR_CAMERA_NAME;
-}
-
-sensor_msgs::msg::CameraInfo cameraInfo(
-  const sensor_msgs::msg::Image & image,
-  float horizontal_fov)
-{
-  sensor_msgs::msg::CameraInfo info_msg;
-
-  info_msg.header = image.header;
-  info_msg.distortion_model = "plumb_bob";
-  info_msg.height = image.height;
-  info_msg.width = image.width;
-
-  float focal = 0.5 * image.width / tan(0.5 * horizontal_fov);
-
-  info_msg.k[0] = focal;
-  info_msg.k[4] = focal;
-  info_msg.k[2] = info_msg.width * 0.5;
-  info_msg.k[5] = info_msg.height * 0.5;
-  info_msg.k[8] = 1.;
-
-  info_msg.p[0] = info_msg.k[0];
-  info_msg.p[5] = info_msg.k[4];
-  info_msg.p[2] = info_msg.k[2];
-  info_msg.p[6] = info_msg.k[5];
-  info_msg.p[10] = info_msg.k[8];
-
-  //    info_msg.roi.do_rectify = true;
-
-  return info_msg;
-}
-}  // namespace
+}  // namespace realsense_gazebo_plugin


### PR DESCRIPTION
This PR updates realsense_gazebo_plugin to work with ROS 2 Jazzy and Gazebo Harmonic instead of Gazebo Classic.

The plugin now uses Harmonic’s gz-sim / gz-transport APIs and reads its camera settings from SDF. It still exposes the same ROS outputs for images, camera info, and point clouds, but now gets its data from Gazebo Harmonic’s native sensor topics.

The migration also includes a few stability fixes: ROS messages now keep Gazebo simulation timestamps, absolute topic names are handled correctly, and point cloud coloring no longer breaks when color and depth frames arrive out of sync.

The README was also rewritten to document the new Harmonic setup, including the required Gazebo topic parameters and HFOV values.

This migration was done with AI assistance, so I cannot guarantee that it works in every setup or covers every edge case. That said, it works for my use case, and I hope it can still be useful to others working on a similar migration.

A new branch should probably be created. I pushed the PR to `alum-devel` by default.